### PR TITLE
Bundle install possible fix

### DIFF
--- a/capstone_rails/Dockerfile
+++ b/capstone_rails/Dockerfile
@@ -1,7 +1,7 @@
 # this file creates a ruby VM that provides and environment
 # running the capstone software and hosting RSpec and Capybara
 # tests
-FROM ruby:2.2
+FROM ruby:2.3
 MAINTAINER Jim Stafford <jim.stafford@jhu.edu>
 
 # Install firefox (aka iceweasel)


### PR DESCRIPTION
nokogiri, bson and public_suffix is not explicitly specified in the Gemfile, they all complain that they would need ruby 2.3 at least. 
One possible solution is to upgrade then the Ruby version